### PR TITLE
Include mcollective/logger/console_logger explicitly

### DIFF
--- a/mc-debugger
+++ b/mc-debugger
@@ -3,6 +3,7 @@
 require 'rubygems'
 require 'irb'
 require 'mcollective'
+require 'mcollective/logger/console_logger'
 require 'tempfile'
 require 'pp'
 


### PR DESCRIPTION
Upon a fresh install of MCO and the agent debugger today, I was getting errors around an unknown constant, MCollective::Logger::Console_logger. This patch addresses that issue.
